### PR TITLE
Bump elasticsearch repo from 5.x to 6.x

### DIFF
--- a/docker/base/elasticsearch.repo
+++ b/docker/base/elasticsearch.repo
@@ -1,6 +1,6 @@
-[elasticsearch-kibana-logstash-5.x]
-name=ELK repository for 5.x packages
-baseurl=https://artifacts.elastic.co/packages/5.x/yum
+[elasticsearch-kibana-logstash-6.x]
+name=ELK repository for 6.x packages
+baseurl=https://artifacts.elastic.co/packages/6.x/yum
 gpgcheck=1
 gpgkey=https://artifacts.elastic.co/GPG-KEY-elasticsearch
 enabled=1

--- a/docker/base/sources.list.debian
+++ b/docker/base/sources.list.debian
@@ -14,7 +14,7 @@ deb https://packages.grafana.com/oss/deb stable main
 deb [arch=arm64] https://dl.bintray.com/fg2it/deb-arm64/ stretch main
 
 # elasticsearch (arch:all), logstash (arch:all), kibana (arch:amd64)
-deb [arch=amd64] https://artifacts.elastic.co/packages/5.x/apt stable main
+deb [arch=amd64] https://artifacts.elastic.co/packages/6.x/apt stable main
 
 # main docker repo
 deb https://download.docker.com/linux/debian stretch stable

--- a/docker/base/sources.list.ubuntu
+++ b/docker/base/sources.list.ubuntu
@@ -13,7 +13,7 @@ deb http://archive.ubuntu.com/ubuntu/ bionic-backports main restricted universe 
 deb http://ubuntu-cloud.archive.canonical.com/ubuntu bionic-updates/rocky main
 
 # Elasticsearch, Logstash & Kibana repo
-deb https://artifacts.elastic.co/packages/5.x/apt stable main
+deb https://artifacts.elastic.co/packages/6.x/apt stable main
 
 # InfluxDB repo
 deb https://repos.influxdata.com/ubuntu bionic stable


### PR DESCRIPTION
This may break Monasca which can be fixed when it's fully backported
to Rocky.