### PR TITLE
Add Prometheus libvirt exporter and Elasticsearch exporter images

### DIFF
--- a/docker/prometheus/prometheus-elasticsearch-exporter/Dockerfile.j2
+++ b/docker/prometheus/prometheus-elasticsearch-exporter/Dockerfile.j2
@@ -1,0 +1,20 @@
+FROM {{ namespace }}/{{ image_prefix }}prometheus-base:{{ tag }}
+LABEL maintainer="{{ maintainer }}" name="{{ image_name }}" build-date="{{ build_date }}"
+
+{% block prometheus_elasticsearch_exporter_header %}{% endblock %}
+
+{% block prometheus_elasticsearch_exporter_repository_version %}
+ENV elasticsearch_exporter_version=1.0.2
+{% endblock %}
+
+{% block prometheus_elasticsearch_exporter_install %}
+RUN curl -sSL -o /tmp/elasticsearch_exporter.tar.gz https://github.com/justwatchcom/elasticsearch_exporter/releases/download/v${elasticsearch_exporter_version}/elasticsearch_exporter-${elasticsearch_exporter_version}.linux-amd64.tar.gz \
+    && tar xvf /tmp/elasticsearch_exporter.tar.gz -C /opt/ \
+    && rm -f /tmp/elasticsearch_exporter.tar.gz \
+    && ln -s /opt/elasticsearch_exporter* /opt/elasticsearch_exporter
+{% endblock %}
+
+{% block prometheus_elasticsearch_exporter_footer %}{% endblock %}
+{% block footer %}{% endblock %}
+
+USER prometheus

--- a/docker/prometheus/prometheus-libvirt-exporter/Dockerfile.j2
+++ b/docker/prometheus/prometheus-libvirt-exporter/Dockerfile.j2
@@ -1,0 +1,45 @@
+FROM {{ namespace }}/{{ image_prefix }}prometheus-base:{{ tag }}
+LABEL maintainer="{{ maintainer }}" name="{{ image_name }}" build-date="{{ build_date }}"
+
+{% import "macros.j2" as macros with context %}
+
+{% block prometheus_libvirt_exporter_header %}{% endblock %}
+
+{% if base_distro in ['centos', 'oraclelinux', 'rhel'] %}
+    {% set prometheus_libvirt_exporter_packages = [
+        'go',
+        'libvirt-devel',
+    ] %}
+{% elif base_distro in ['debian', 'ubuntu'] %}
+    {% set prometheus_libvirt_exporter_packages = [
+        'golang-go',
+        'libvirt-dev',
+    ] %}
+{% endif %}
+
+{{ macros.install_packages(prometheus_libvirt_exporter_packages | customizable("packages")) }}
+
+{% block prometheus_libvirt_exporter_version %}
+ARG prometheus_libvirt_exporter_version=0.1.1
+ARG prometheus_libvirt_exporter_url=https://github.com/kumina/libvirt_exporter.git
+{% endblock %}
+
+{% block prometheus_libvirt_exporter_install %}
+ENV GOPATH=/build
+RUN mkdir /build \
+    && cd /build \
+    && git clone --branch ${prometheus_libvirt_exporter_version} ${prometheus_libvirt_exporter_url} \
+    && cd libvirt_exporter \
+    && go get -d ./... \
+    && go build \
+    && install -m 0755 libvirt_exporter /opt/ \
+    && rm -rf /build
+{% endblock %}
+
+{% block prometheus_libvirt_exporter_footer %}{% endblock %}
+{% block footer %}{% endblock %}
+
+# TODO: Root level access is currently required to read libvirt metrics. In
+# the future we should investigate read only access as a non-root user. See
+# https://libvirt.org/auth.html#ACL_server_polkit.
+USER root

--- a/releasenotes/notes/add-prometheus-libvirt-exporter-8d505dc8b74f8625.yaml
+++ b/releasenotes/notes/add-prometheus-libvirt-exporter-8d505dc8b74f8625.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - Added a container image for Prometheus libvirt exporter, to be used
+    for monitoring deployments which provide VMs with libvirt.


### PR DESCRIPTION
This adds a libvirt exporter image for use with Prometheus.

Change-Id: Ice2af99a323496d3821762851b663899d15f569a