### PR TITLE
Bump td.repo to supported version 3

### DIFF
--- a/docker/base/td.repo
+++ b/docker/base/td.repo
@@ -1,5 +1,5 @@
 [treasuredata]
 name=TreasureData
-baseurl=http://packages.treasuredata.com/2/redhat/\$releasever/\$basearch
+baseurl=http://packages.treasuredata.com/3/redhat/\$releasever/\$basearch
 gpgcheck=1
 gpgkey=https://packages.treasuredata.com/GPG-KEY-td-agent


### PR DESCRIPTION
This appears to bump fluent to v0.14 which hopefully includes
emit_unmatched_lines option we want.